### PR TITLE
Fix camera capture issues on Raspberry Pi 5

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -22,6 +22,11 @@ This guide covers installing the aircraft detection system on a Raspberry Pi wit
    sudo apt install -y python3-opencv python3-flask python3-numpy
    ```
 4. Enable the camera interface using `raspi-config` if it is not already enabled.
+5. If using the libcamera stack (default on recent Raspberry Pi OS releases),
+   ensure the V4L2 compatibility driver is loaded:
+   ```bash
+   sudo modprobe bcm2835-v4l2
+   ```
 
 ## Running the Detector
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Refer to [INSTALLATION.md](INSTALLATION.md) for a detailed setup guide. In short
 
 If you encounter issues, check console output for specific error messages and verify the camera cable connections.
 
+If frames fail to capture even though the camera is detected ("Failed to capture frame" messages), ensure that the V4L2 compatibility driver is loaded and that the camera supports MJPEG output.  The built in `RPiCamera` class now sets the ``MJPG`` format automatically, but older installs may require enabling the legacy camera driver with ``modprobe bcm2835-v4l2``.
+
 For detailed troubleshooting, see [INSTALLATION.md](INSTALLATION.md).
 
 ### Command Summary for Users

--- a/rpi_camera.py
+++ b/rpi_camera.py
@@ -5,34 +5,63 @@ This minimal class captures frames from any Raspberry Pi compatible
 camera via the standard V4L2 interface. It avoids Arducam specific
 requirements and should work with the official camera module and most
 USB webcams.
+
+The initial implementation used ``cv2.VideoCapture`` with default
+settings.  On some Pi models this results in repeated ``read`` failures
+even though ``VideoCapture`` reports it opened successfully.  The camera
+often requires an explicit FOURCC setting (``MJPG``) when accessed via
+the V4L2 compatibility layer provided by ``libcamera``.  Without this the
+driver may deliver frames in an unsupported raw format and OpenCV will
+return ``ret=False``.
+
+This module now allows specifying a ``fourcc`` code and applies it during
+initialisation to improve compatibility with ``libcamera`` devices.
 """
 
 import cv2
+import logging
 
 
 class RPiCamera:
-    """Lightweight camera wrapper."""
+    """Lightweight camera wrapper for V4L2/``libcamera`` devices."""
 
-    def __init__(self, device=0, resolution=(1920, 1080), framerate=30):
+    def __init__(self, device=0, resolution=(1920, 1080), framerate=30,
+                 fourcc="MJPG"):
         self.device = device
         self.resolution = resolution
         self.framerate = framerate
+        self.fourcc = fourcc
         self.cap = None
 
     def initialize(self):
-        self.cap = cv2.VideoCapture(self.device)
+        """Initialise the camera and apply configuration."""
+        self.cap = cv2.VideoCapture(self.device, cv2.CAP_V4L2)
         if not self.cap.isOpened():
             return False
+
+        # Configure stream properties.  Not all properties are honoured by the
+        # driver but failures here are non-fatal.
         self.cap.set(cv2.CAP_PROP_FRAME_WIDTH, self.resolution[0])
         self.cap.set(cv2.CAP_PROP_FRAME_HEIGHT, self.resolution[1])
         self.cap.set(cv2.CAP_PROP_FPS, self.framerate)
+        try:
+            fourcc_val = cv2.VideoWriter_fourcc(*self.fourcc)
+            self.cap.set(cv2.CAP_PROP_FOURCC, fourcc_val)
+        except Exception:
+            pass
+
+        # Give the camera a moment to warm up
+        cv2.waitKey(100)
         return True
 
     def capture_frame(self):
         if not self.cap:
             return None
         ret, frame = self.cap.read()
-        return frame if ret else None
+        if not ret:
+            logging.warning("Frame capture failed")
+            return None
+        return frame
 
     def release(self):
         if self.cap:


### PR DESCRIPTION
## Summary
- use explicit MJPG fourcc when opening camera to avoid bad frame reads
- document that libcamera needs V4L2 compatibility driver
- mention MJPG requirement in troubleshooting guide

## Testing
- `python3 -m py_compile *.py`