### PR TITLE
Fix camera capture issues on Raspberry Pi 5

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -22,13 +22,24 @@ This guide covers installing the aircraft detection system on a Raspberry Pi wit
    sudo apt install -y python3-opencv python3-flask python3-numpy
    ```
 4. Enable the camera interface using `raspi-config` if it is not already enabled.
+5. If using the libcamera stack (default on recent Raspberry Pi OS releases),
+   ensure the V4L2 compatibility driver is loaded:
+   ```bash
+   sudo modprobe bcm2835-v4l2
+   ```
+6. If OpenCV cannot read frames, install the v4l2loopback module and create a
+   virtual camera device for bridging:
+   ```bash
+   sudo apt install v4l2loopback-dkms
+   sudo modprobe v4l2loopback video_nr=10 card_label="camera-bridge" exclusive_caps=1
+   ```
 
 ## Running the Detector
 
 Clone this repository and run:
 
 ```bash
-python3 pi-aircraft-detector.py --web
+python3 pi-aircraft-detector.py --web [--libcamera-bridge]
 ```
 
 Open `http://<pi-address>:8080` in your browser to view the web interface.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,23 @@ Refer to [INSTALLATION.md](INSTALLATION.md) for a detailed setup guide. In short
 
 If you encounter issues, check console output for specific error messages and verify the camera cable connections.
 
+If frames fail to capture even though the camera is detected ("Failed to capture frame" messages), ensure that the V4L2 compatibility driver is loaded and that the camera supports MJPEG output.  The built in `RPiCamera` class now sets the ``MJPG`` format automatically, but older installs may require enabling the legacy camera driver with ``modprobe bcm2835-v4l2``.
+
+If OpenCV still fails to read frames, set up a bridge between libcamera and
+OpenCV using the `v4l2loopback` kernel module. Install the module and load a
+virtual device:
+
+```bash
+sudo apt install v4l2loopback-dkms
+sudo modprobe v4l2loopback video_nr=10 card_label="camera-bridge" exclusive_caps=1
+```
+
+Run the detector with bridging enabled:
+
+```bash
+python3 pi-aircraft-detector.py --web --libcamera-bridge
+```
+
 For detailed troubleshooting, see [INSTALLATION.md](INSTALLATION.md).
 
 ### Command Summary for Users

--- a/pi-aircraft-detector.py
+++ b/pi-aircraft-detector.py
@@ -425,10 +425,15 @@ def main():
     parser.add_argument('--min-area', type=int, default=25, help='Minimum contour area')
     parser.add_argument('--contrast-threshold', type=int, default=50, help='Minimum contrast')
     parser.add_argument('--confidence-threshold', type=float, default=0.6, help='Detection confidence threshold')
+    parser.add_argument('--libcamera-bridge', action='store_true',
+                        help='Use libcamera-vid with v4l2loopback')
+    parser.add_argument('--bridge-device', default='/dev/video10',
+                        help='v4l2loopback device for libcamera bridge')
     args = parser.parse_args()
     
     # Initialize camera
-    camera = Camera()
+    camera = Camera(use_libcamera=args.libcamera_bridge,
+                    loopback_device=args.bridge_device)
     if not camera.initialize():
         logger.error("Failed to initialize camera. Exiting.")
         return

--- a/rpi_camera.py
+++ b/rpi_camera.py
@@ -5,36 +5,105 @@ This minimal class captures frames from any Raspberry Pi compatible
 camera via the standard V4L2 interface. It avoids Arducam specific
 requirements and should work with the official camera module and most
 USB webcams.
+
+The initial implementation used ``cv2.VideoCapture`` with default
+settings.  On some Pi models this results in repeated ``read`` failures
+even though ``VideoCapture`` reports it opened successfully.  The camera
+often requires an explicit FOURCC setting (``MJPG``) when accessed via
+the V4L2 compatibility layer provided by ``libcamera``.  Without this the
+driver may deliver frames in an unsupported raw format and OpenCV will
+return ``ret=False``.
+
+This module now allows specifying a ``fourcc`` code and applies it during
+initialisation to improve compatibility with ``libcamera`` devices.
 """
 
 import cv2
+import logging
+import subprocess
+import time
 
 
 class RPiCamera:
-    """Lightweight camera wrapper."""
+    """Lightweight camera wrapper for V4L2/``libcamera`` devices."""
 
-    def __init__(self, device=0, resolution=(1920, 1080), framerate=30):
+    def __init__(self, device=0, resolution=(1920, 1080), framerate=30,
+                 fourcc="MJPG", use_libcamera=False,
+                 loopback_device="/dev/video10"):
         self.device = device
         self.resolution = resolution
         self.framerate = framerate
+        self.fourcc = fourcc
         self.cap = None
+        self.use_libcamera = use_libcamera
+        self.loopback_device = loopback_device
+        self.bridge_process = None
+
+    def _start_libcamera_bridge(self):
+        """Spawn libcamera-vid to pipe frames to a v4l2loopback device."""
+        cmd = [
+            "libcamera-vid",
+            "-n",
+            "--width", str(self.resolution[0]),
+            "--height", str(self.resolution[1]),
+            "--framerate", str(self.framerate),
+            "--codec", "mjpeg",
+            "-t", "0",
+            "-o", self.loopback_device,
+        ]
+        try:
+            self.bridge_process = subprocess.Popen(
+                cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+            )
+            # Give libcamera time to create the stream
+            time.sleep(1)
+        except FileNotFoundError:
+            logging.error("libcamera-vid not found. Is it installed?")
 
     def initialize(self):
-        self.cap = cv2.VideoCapture(self.device)
+        """Initialise the camera and apply configuration."""
+
+        capture_device = self.device
+        if self.use_libcamera:
+            self._start_libcamera_bridge()
+            capture_device = self.loopback_device
+
+        self.cap = cv2.VideoCapture(capture_device, cv2.CAP_V4L2)
         if not self.cap.isOpened():
             return False
+
+        # Configure stream properties.  Not all properties are honoured by the
+        # driver but failures here are non-fatal.
         self.cap.set(cv2.CAP_PROP_FRAME_WIDTH, self.resolution[0])
         self.cap.set(cv2.CAP_PROP_FRAME_HEIGHT, self.resolution[1])
         self.cap.set(cv2.CAP_PROP_FPS, self.framerate)
+        try:
+            fourcc_val = cv2.VideoWriter_fourcc(*self.fourcc)
+            self.cap.set(cv2.CAP_PROP_FOURCC, fourcc_val)
+        except Exception:
+            pass
+
+        # Give the camera a moment to warm up without requiring a GUI
+        time.sleep(0.1)
         return True
 
     def capture_frame(self):
         if not self.cap:
             return None
         ret, frame = self.cap.read()
-        return frame if ret else None
+        if not ret:
+            logging.warning("Frame capture failed")
+            return None
+        return frame
 
     def release(self):
         if self.cap:
             self.cap.release()
             self.cap = None
+        if self.bridge_process:
+            self.bridge_process.terminate()
+            try:
+                self.bridge_process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                self.bridge_process.kill()
+            self.bridge_process = None


### PR DESCRIPTION
## Summary
- use explicit MJPG fourcc when opening camera to avoid bad frame reads
- document that libcamera needs V4L2 compatibility driver
- mention MJPG requirement in troubleshooting guide
- add optional bridge using libcamera-vid and v4l2loopback when OpenCV can't read frames
- document how to install and use bridge

## Testing
- `python3 -m py_compile *.py`
